### PR TITLE
This commit renames to splunk-server

### DIFF
--- a/splunk.nuspec
+++ b/splunk.nuspec
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
-    <id>splunk</id>
+    <id>splunk-server</id>
     <version>7.1.3</version>
-    <packageSourceUrl>https://download.splunk.com/products/splunk/releases/7.1.3/windows/</packageSourceUrl>
+    <packageSourceUrl>https://github.com/ralfbosz/package_splunk</packageSourceUrl>
     <owners>Ralf Bosz</owners>
     <title>Splunk Enterprise</title>
     <authors>Splunk Inc.</authors>


### PR DESCRIPTION
Seems splunk is allready taken on chocolatey.org
(with a very old version). Fixed url to this GitHub
page.